### PR TITLE
Vratene zasielky sa spravaju ako vratene

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,7 +2,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    exclude: 'CakePHP.Commenting.FunctionComment.MissingParamComment,CakePHP.Commenting.FunctionComment.Missing'
+#    exclude: 'CakePHP.Commenting.FunctionComment.MissingParamComment,CakePHP.Commenting.FunctionComment.Missing'
     extensions: 'php,ctp'
     fixer: true
 

--- a/src/Endpoints/SlovenskaPostaEndpoint.php
+++ b/src/Endpoints/SlovenskaPostaEndpoint.php
@@ -9,6 +9,7 @@ use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\NotifiedState;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\ReceivedState;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\State;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\UnknownState;
+use RuntimeException;
 
 class SlovenskaPostaEndpoint extends Endpoint
 {
@@ -82,6 +83,7 @@ class SlovenskaPostaEndpoint extends Endpoint
             case 'notified':
                 return NotifiedState::class;
             case 'delivered':
+            case 'returned':
                 return DeliveredState::class;
         }
 
@@ -99,6 +101,6 @@ class SlovenskaPostaEndpoint extends Endpoint
             return $url;
         }
 
-        throw new \RuntimeException('Invalid $url type');
+        throw new RuntimeException('Invalid $url type');
     }
 }

--- a/src/Endpoints/SlovenskaPostaEndpoint.php
+++ b/src/Endpoints/SlovenskaPostaEndpoint.php
@@ -7,6 +7,7 @@ use MartinusDev\ShipmentsTracking\Shipment\Shipment;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\DeliveredState;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\NotifiedState;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\ReceivedState;
+use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\ReturnedState;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\State;
 use MartinusDev\ShipmentsTracking\Shipment\ShipmentStates\UnknownState;
 use RuntimeException;
@@ -83,8 +84,9 @@ class SlovenskaPostaEndpoint extends Endpoint
             case 'notified':
                 return NotifiedState::class;
             case 'delivered':
-            case 'returned':
                 return DeliveredState::class;
+            case 'returned':
+                return ReturnedState::class;
         }
 
         return UnknownState::class;

--- a/src/Shipment/ShipmentStates/ReturnedState.php
+++ b/src/Shipment/ShipmentStates/ReturnedState.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MartinusDev\ShipmentsTracking\Shipment\ShipmentStates;
+
+class ReturnedState extends State
+{
+    protected $name = 'returned';
+}

--- a/tests/TestCase/Endpoints/SlovenskaPostaEndpointTest.php
+++ b/tests/TestCase/Endpoints/SlovenskaPostaEndpointTest.php
@@ -70,6 +70,12 @@ class SlovenskaPostaEndpointTest extends TestCase
                 ],
                 'delivered',
             ],
+            [
+                [
+                    'state' => 'returned',
+                ],
+                'delivered',
+            ],
         ];
     }
 }

--- a/tests/TestCase/Endpoints/SlovenskaPostaEndpointTest.php
+++ b/tests/TestCase/Endpoints/SlovenskaPostaEndpointTest.php
@@ -74,7 +74,7 @@ class SlovenskaPostaEndpointTest extends TestCase
                 [
                     'state' => 'returned',
                 ],
-                'delivered',
+                'returned',
             ],
         ];
     }


### PR DESCRIPTION
@samuelszabo myslis, ze mozeme nieco taketo spravit? Riesim padnute tasky v `queue_shipments_tracking`, vacsina su vratene zasielky.

Alternativne este ReturnedState objekt a v martinuse mu dame (rovnako, ako ma DeliveredState) cislo 90 = completed.

Docasne znizujem o 10 pocet attemptov tym taskom :) to by malo stacit na tyzden