### PR TITLE
Fix/GLS/Exception

### DIFF
--- a/src/Endpoints/GlsTrait.php
+++ b/src/Endpoints/GlsTrait.php
@@ -22,6 +22,10 @@ trait GlsTrait
      */
     public function parseResponse(string $responseString): array
     {
+        if ($responseString === 'Err#02: Parcel number(s) not found in database') {
+            return [];
+        }
+
         $response = new \SimpleXMLElement($responseString);
         $events = [];
         foreach ($response->Parcel->Statuses->Status as $status) {

--- a/tests/TestCase/Endpoints/GLSEndpointTest.php
+++ b/tests/TestCase/Endpoints/GLSEndpointTest.php
@@ -13,9 +13,8 @@ class GLSEndpointTest extends TestCase
     public function testUnknownParcelNumber(): void
     {
         $endpoint = new GlsSkEndpoint();
-        $this->expectException(Exception::class);
         $response = $endpoint->parseResponse('Err#02: Parcel number(s) not found in database');
-        $this->assertNull($response);
+        $this->assertSame([], $response);
     }
 
     public function testParseResponse(): void


### PR DESCRIPTION
Nespravne pochopenie SlovenskejPosty, ktora aj v pripade nenajdenia posiela validny JSON oproti GLS.
Vo vacsinovom pripade, kedy zacneme sledovat zasielku, tak prve requesty dostavame obycajny string s error hlaskou, ze GLS tuto zasielku (este) neeviduje. V tomto pripade nechceme ziadnu exception, len prazdne pole eventov.
V pripade inych error hlasok nechavam este neodchytenu exception.