### PR TITLE
Feature/Get carrier by name

### DIFF
--- a/src/ShipmentsTracking.php
+++ b/src/ShipmentsTracking.php
@@ -101,6 +101,7 @@ class ShipmentsTracking
 
         /** @var string|\MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrierNamespaceName */
         $carrierNamespaceName = Carrier::getNamespaceName($name);
+
         return new $carrierNamespaceName();
     }
 

--- a/src/ShipmentsTracking.php
+++ b/src/ShipmentsTracking.php
@@ -84,9 +84,25 @@ class ShipmentsTracking
      */
     public function get(string $number, array $options = []): Shipment
     {
-        $carrier = $this->detectCarrier($number, $options);
+        if (isset($options['carrier'])) {
+            $carrier = $this->getCarrierByName($options['carrier']);
+        } else {
+            $carrier = $this->detectCarrier($number, $options);
+        }
 
         return $carrier->getShipment($number, $options);
+    }
+
+    private function getCarrierByName(string $name): CarrierInterface
+    {
+        if (!in_array($name, Carrier::CARRIERS)) {
+            return new UnknownCarrier();
+        }
+
+        /** @var string|\MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrierNamespaceName */
+        $carrierNamespaceName = Carrier::getNamespaceName($name);
+        /** @var \MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrier */
+        return new $carrierNamespaceName();
     }
 
     /**

--- a/src/ShipmentsTracking.php
+++ b/src/ShipmentsTracking.php
@@ -101,7 +101,6 @@ class ShipmentsTracking
 
         /** @var string|\MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrierNamespaceName */
         $carrierNamespaceName = Carrier::getNamespaceName($name);
-        /** @var \MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrier */
         return new $carrierNamespaceName();
     }
 

--- a/tests/TestCase/ShipmentsTrackingTest.php
+++ b/tests/TestCase/ShipmentsTrackingTest.php
@@ -2,6 +2,7 @@
 
 namespace MartinusDev\ShipmentsTracking\Test\TestCase;
 
+use MartinusDev\ShipmentsTracking\Carriers\GlsSkCarrier;
 use MartinusDev\ShipmentsTracking\Carriers\UnknownCarrier;
 use MartinusDev\ShipmentsTracking\Shipment\Shipment;
 use MartinusDev\ShipmentsTracking\ShipmentsTracking;
@@ -62,5 +63,13 @@ class ShipmentsTrackingTest extends \PHPUnit\Framework\TestCase
         $shipment = $shipmentsTracking->get('abc');
         $this->assertInstanceOf(Shipment::class, $shipment);
         $this->assertSame('{"number":"abc","carrierName":"Unknown","trackingLink":"","states":[]}', json_encode($shipment));
+    }
+
+    public function testGetWithCarrierOption()
+    {
+        $shipmentsTracking = new ShipmentsTracking();
+        $shipment = $shipmentsTracking->get('abc', ['carrier' => GlsSkCarrier::NAME]);
+        $this->assertInstanceOf(Shipment::class, $shipment);
+        $this->assertSame('{"number":"abc","carrierName":"GlsSk","trackingLink":"https:\/\/gls-group.eu\/SK\/sk\/sledovanie-zasielok?match=abc","states":[]}', json_encode($shipment));
     }
 }


### PR DESCRIPTION
Ak vieme konkretneho prepravcu, mozeme si ho tam poslat a nemusime sa spoliehat na regexy, ktore casom mozu zastarat, kedze cisla su inkrementalne a predpokladame, ze sa budu casom navysovat, nie prepouzivat. Tym by sme museli pravidelne upravovat regexy aby to fungovalo dalej. A hlavne, kto si na to spomenie pri nahadzovani novych rozsahov pridelenych cisiel od prepravcov...