### PR TITLE
SPS: silent error pri nenajdenej zasielke

### DIFF
--- a/src/Endpoints/SPSEndpoint.php
+++ b/src/Endpoints/SPSEndpoint.php
@@ -96,7 +96,7 @@ class SPSEndpoint extends Endpoint
         $this->statuses = $this->client->getParcelStatus((int)$SPSParcelNumber->landNr, (int)$SPSParcelNumber->manNr, (int)$SPSParcelNumber->lfdNr, 'E');
 
         if (!is_array($this->statuses)) {
-            throw new \Exception('Statuses is not an array (' . json_encode($this->statuses) . ') for shipment.number ' . $shipment->number);
+            $this->statuses = [];
         }
 
         return $this->parseResponse('');


### PR DESCRIPTION
oprava [dnesnej](https://github.com/martinusdev/shipments-tracking/pull/23) vynutenej vynimky pri nenajdenej zasielke; ak zasielka neexistuje, vraciam prazdne statuses (odbobne ako pri inych prepravcoch)