### PR TITLE
Výber preferovaného jazyka pre tracking link

### DIFF
--- a/src/Carriers/Carrier.php
+++ b/src/Carriers/Carrier.php
@@ -28,6 +28,10 @@ class Carrier implements CarrierInterface
      * @var ?\MartinusDev\ShipmentsTracking\Endpoints\Endpoint
      */
     protected $endPoint;
+    /**
+     * @var array<string>
+     */
+    protected $languages;
 
     /**
      * @param string $carrierName
@@ -61,9 +65,13 @@ class Carrier implements CarrierInterface
      */
     public function __construct(array $options = [])
     {
+        $options += [
+            'languages' => []
+        ];
         if ($this->endPointClass) {
             $this->endPoint = new $this->endPointClass($options);
         }
+        $this->languages = $options['languages'];
     }
 
     /**

--- a/src/Carriers/Carrier.php
+++ b/src/Carriers/Carrier.php
@@ -66,7 +66,7 @@ class Carrier implements CarrierInterface
     public function __construct(array $options = [])
     {
         $options += [
-            'languages' => []
+            'languages' => [],
         ];
         if ($this->endPointClass) {
             $this->endPoint = new $this->endPointClass($options);

--- a/src/Carriers/PacketaCarrier.php
+++ b/src/Carriers/PacketaCarrier.php
@@ -24,6 +24,45 @@ class PacketaCarrier extends Carrier
      */
     public function getTrackingUrl(string $number): string
     {
-        return preg_replace(self::REGEX, 'https://tracking.packeta.com/en/?id=$1', $number);
+        $lang = $this->getLanguage();
+        $trackingUrl = 'https://tracking.packeta.com/' . $lang . '/?id=$1';
+
+        return preg_replace(self::REGEX, $trackingUrl, $number);
+    }
+
+    private function getLanguage(): string
+    {
+        $supportedLanguages = [
+            'cs',
+            'de',
+            'hu',
+            'sk',
+            'pl',
+            'ro',
+            'uk',
+            'es',
+            'fr',
+            'be',
+            'pt',
+            'ru',
+            'sv',
+            'el',
+            'it',
+            'bg',
+            'sl',
+            'hr',
+            'lv',
+            'lt',
+            'et',
+            'da',
+            'fi',
+        ];
+        foreach ($this->languages as $language) {
+            if (in_array($language, $supportedLanguages)) {
+                return $language;
+            }
+        }
+
+        return 'en';
     }
 }

--- a/src/ShipmentsTracking.php
+++ b/src/ShipmentsTracking.php
@@ -18,6 +18,10 @@ class ShipmentsTracking
      * @var string[]
      */
     protected $preferredCarriers = [];
+    /**
+     * @var array<string> List of preferred languages, ISO 639-1 codes
+     */
+    private $languages;
 
     /**
      * @param array<string,mixed> $options
@@ -27,12 +31,14 @@ class ShipmentsTracking
         $options += [
             'client' => null,
             'preferredCarriers' => [],
+            'languages' => ['en'],
         ];
         if (empty($options['client'])) {
             $options['client'] = new GuzzleHttpClient();
         }
         self::$client = $options['client'];
         $this->preferredCarriers = $options['preferredCarriers'];
+        $this->languages = $options['languages'];
     }
 
     /**
@@ -56,7 +62,7 @@ class ShipmentsTracking
             $regex = constant($carrierNamespaceName . '::REGEX');
             if (preg_match($regex, $number)) {
                 /** @var \MartinusDev\ShipmentsTracking\Carriers\CarrierInterface $carrier */
-                $carrier = new $carrierNamespaceName();
+                $carrier = new $carrierNamespaceName(['languages' => $this->languages]);
 
                 return $carrier;
             }

--- a/tests/TestCase/Carrier/PacketaCarrierTest.php
+++ b/tests/TestCase/Carrier/PacketaCarrierTest.php
@@ -14,4 +14,10 @@ class PacketaCarrierTest extends TestCase
         $carrier = Carrier::load(PacketaCarrier::NAME);
         $this->assertSame('https://tracking.packeta.com/en/?id=Z4964561515', $carrier->getTrackingUrl('Z4964561515'));
     }
+
+    public function testGetTrackingUrlCs()
+    {
+        $carrier = Carrier::load(PacketaCarrier::NAME, ['languages' => ['unknown', 'cs', 'em']]);
+        $this->assertSame('https://tracking.packeta.com/cs/?id=Z4964561515', $carrier->getTrackingUrl('Z4964561515'));
+    }
 }

--- a/tests/TestCase/Carrier/PacketaCarrierTest.php
+++ b/tests/TestCase/Carrier/PacketaCarrierTest.php
@@ -17,7 +17,7 @@ class PacketaCarrierTest extends TestCase
 
     public function testGetTrackingUrlCs()
     {
-        $carrier = Carrier::load(PacketaCarrier::NAME, ['languages' => ['unknown', 'cs', 'em']]);
+        $carrier = Carrier::load(PacketaCarrier::NAME, ['languages' => ['unknown', 'cs', 'en']]);
         $this->assertSame('https://tracking.packeta.com/cs/?id=Z4964561515', $carrier->getTrackingUrl('Z4964561515'));
     }
 }


### PR DESCRIPTION
Umožní definovať preferovaný jazyk trackovacieho odkazu. Viacero možností je dôvodu ak prepravca nepodporuje daný jazyk, vyberie sa ďalší v poradí.